### PR TITLE
quick fix to exception handling

### DIFF
--- a/lib/routerExceptionHandler.js
+++ b/lib/routerExceptionHandler.js
@@ -21,7 +21,7 @@ const routerExceptionHandler = () => {
       this.__handle = newFn;
     },
   });
-  const origParamFn = Router.prototype.param;
+  const origParamFn = Router.prototype.constructor.param;
   Router.param = (name, fn) => origParamFn(name, wrapperHandlerFunction(fn));
 };
 


### PR DESCRIPTION
fixed accessing param function from constructor instead of just prototype